### PR TITLE
use arviz.InferenceData to store sampling results

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -107,6 +107,33 @@ files = [
 python-dateutil = ">=2.7.0"
 
 [[package]]
+name = "arviz"
+version = "0.15.1"
+description = "Exploratory analysis of Bayesian models"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "arviz-0.15.1-py3-none-any.whl", hash = "sha256:120695738fb81cc39e8da98b8b751f8f08c618267efda2a6dcb3f1511b599311"},
+    {file = "arviz-0.15.1.tar.gz", hash = "sha256:981cce0282bdf6f3b379255b95a440979f9a0ef0ae9dd88a54f763cf5b31484c"},
+]
+
+[package.dependencies]
+h5netcdf = ">=1.0.2"
+matplotlib = ">=3.2"
+numpy = ">=1.20.0"
+packaging = "*"
+pandas = ">=1.3.0"
+scipy = ">=1.8.0"
+setuptools = ">=60.0.0"
+typing-extensions = ">=4.1.0"
+xarray = ">=0.21.0"
+xarray-einstats = ">=0.3"
+
+[package.extras]
+all = ["bokeh (>=1.4.0,<3.0)", "contourpy", "dask[distributed]", "netcdf4", "numba", "ujson", "zarr (>=2.5.0)"]
+
+[[package]]
 name = "asttokens"
 version = "2.2.1"
 description = "Annotate AST trees with source code positions"
@@ -1141,6 +1168,22 @@ colorama = ">=0.4"
 
 [package.extras]
 async = ["aiofiles (>=0.7,<1.0)"]
+
+[[package]]
+name = "h5netcdf"
+version = "1.1.0"
+description = "netCDF4 via h5py"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "h5netcdf-1.1.0-py2.py3-none-any.whl", hash = "sha256:338e65212cee129e4508a49994f230a3083910fbf20454bb57aa1ca99687ad34"},
+    {file = "h5netcdf-1.1.0.tar.gz", hash = "sha256:932c3b573bed7370ebfc9e802cd60f1a4da5236efb11b36eeff897324d76bf56"},
+]
+
+[package.dependencies]
+h5py = "*"
+packaging = "*"
 
 [[package]]
 name = "h5py"
@@ -2634,7 +2677,6 @@ files = [
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
-    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3708,35 +3750,39 @@ tests = ["black (>=22.3.0)", "flake8 (>=3.8.2)", "matplotlib (>=3.1.3)", "mypy (
 
 [[package]]
 name = "scipy"
-version = "1.6.1"
+version = "1.8.1"
 description = "SciPy: Scientific Library for Python"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8,<3.11"
 files = [
-    {file = "scipy-1.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a15a1f3fc0abff33e792d6049161b7795909b40b97c6cc2934ed54384017ab76"},
-    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e79570979ccdc3d165456dd62041d9556fb9733b86b4b6d818af7a0afc15f092"},
-    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a423533c55fec61456dedee7b6ee7dce0bb6bfa395424ea374d25afa262be261"},
-    {file = "scipy-1.6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:33d6b7df40d197bdd3049d64e8e680227151673465e5d85723b3b8f6b15a6ced"},
-    {file = "scipy-1.6.1-cp37-cp37m-win32.whl", hash = "sha256:6725e3fbb47da428794f243864f2297462e9ee448297c93ed1dcbc44335feb78"},
-    {file = "scipy-1.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:5fa9c6530b1661f1370bcd332a1e62ca7881785cc0f80c0d559b636567fab63c"},
-    {file = "scipy-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bd50daf727f7c195e26f27467c85ce653d41df4358a25b32434a50d8870fc519"},
-    {file = "scipy-1.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f46dd15335e8a320b0fb4685f58b7471702234cba8bb3442b69a3e1dc329c345"},
-    {file = "scipy-1.6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0e5b0ccf63155d90da576edd2768b66fb276446c371b73841e3503be1d63fb5d"},
-    {file = "scipy-1.6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2481efbb3740977e3c831edfd0bd9867be26387cacf24eb5e366a6a374d3d00d"},
-    {file = "scipy-1.6.1-cp38-cp38-win32.whl", hash = "sha256:68cb4c424112cd4be886b4d979c5497fba190714085f46b8ae67a5e4416c32b4"},
-    {file = "scipy-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:5f331eeed0297232d2e6eea51b54e8278ed8bb10b099f69c44e2558c090d06bf"},
-    {file = "scipy-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0c8a51d33556bf70367452d4d601d1742c0e806cd0194785914daf19775f0e67"},
-    {file = "scipy-1.6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:83bf7c16245c15bc58ee76c5418e46ea1811edcc2e2b03041b804e46084ab627"},
-    {file = "scipy-1.6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:794e768cc5f779736593046c9714e0f3a5940bc6dcc1dba885ad64cbfb28e9f0"},
-    {file = "scipy-1.6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5da5471aed911fe7e52b86bf9ea32fb55ae93e2f0fac66c32e58897cfb02fa07"},
-    {file = "scipy-1.6.1-cp39-cp39-win32.whl", hash = "sha256:8e403a337749ed40af60e537cc4d4c03febddcc56cd26e774c9b1b600a70d3e4"},
-    {file = "scipy-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5193a098ae9f29af283dcf0041f762601faf2e595c0db1da929875b7570353f"},
-    {file = "scipy-1.6.1.tar.gz", hash = "sha256:c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11"},
+    {file = "scipy-1.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:65b77f20202599c51eb2771d11a6b899b97989159b7975e9b5259594f1d35ef4"},
+    {file = "scipy-1.8.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e013aed00ed776d790be4cb32826adb72799c61e318676172495383ba4570aa4"},
+    {file = "scipy-1.8.1-cp310-cp310-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:02b567e722d62bddd4ac253dafb01ce7ed8742cf8031aea030a41414b86c1125"},
+    {file = "scipy-1.8.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1da52b45ce1a24a4a22db6c157c38b39885a990a566748fc904ec9f03ed8c6ba"},
+    {file = "scipy-1.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0aa8220b89b2e3748a2836fbfa116194378910f1a6e78e4675a095bcd2c762d"},
+    {file = "scipy-1.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:4e53a55f6a4f22de01ffe1d2f016e30adedb67a699a310cdcac312806807ca81"},
+    {file = "scipy-1.8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:28d2cab0c6ac5aa131cc5071a3a1d8e1366dad82288d9ec2ca44df78fb50e649"},
+    {file = "scipy-1.8.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:6311e3ae9cc75f77c33076cb2794fb0606f14c8f1b1c9ff8ce6005ba2c283621"},
+    {file = "scipy-1.8.1-cp38-cp38-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:3b69b90c9419884efeffaac2c38376d6ef566e6e730a231e15722b0ab58f0328"},
+    {file = "scipy-1.8.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6cc6b33139eb63f30725d5f7fa175763dc2df6a8f38ddf8df971f7c345b652dc"},
+    {file = "scipy-1.8.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c4e3ae8a716c8b3151e16c05edb1daf4cb4d866caa385e861556aff41300c14"},
+    {file = "scipy-1.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23b22fbeef3807966ea42d8163322366dd89da9bebdc075da7034cee3a1441ca"},
+    {file = "scipy-1.8.1-cp38-cp38-win32.whl", hash = "sha256:4b93ec6f4c3c4d041b26b5f179a6aab8f5045423117ae7a45ba9710301d7e462"},
+    {file = "scipy-1.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:70ebc84134cf0c504ce6a5f12d6db92cb2a8a53a49437a6bb4edca0bc101f11c"},
+    {file = "scipy-1.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f3e7a8867f307e3359cc0ed2c63b61a1e33a19080f92fe377bc7d49f646f2ec1"},
+    {file = "scipy-1.8.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:2ef0fbc8bcf102c1998c1f16f15befe7cffba90895d6e84861cd6c6a33fb54f6"},
+    {file = "scipy-1.8.1-cp39-cp39-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:83606129247e7610b58d0e1e93d2c5133959e9cf93555d3c27e536892f1ba1f2"},
+    {file = "scipy-1.8.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93d07494a8900d55492401917a119948ed330b8c3f1d700e0b904a578f10ead4"},
+    {file = "scipy-1.8.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3b3c8924252caaffc54d4a99f1360aeec001e61267595561089f8b5900821bb"},
+    {file = "scipy-1.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70de2f11bf64ca9921fda018864c78af7147025e467ce9f4a11bc877266900a6"},
+    {file = "scipy-1.8.1-cp39-cp39-win32.whl", hash = "sha256:1166514aa3bbf04cb5941027c6e294a000bba0cf00f5cdac6c77f2dad479b434"},
+    {file = "scipy-1.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:9dd4012ac599a1e7eb63c114d1eee1bcfc6dc75a29b589ff0ad0bb3d9412034f"},
+    {file = "scipy-1.8.1.tar.gz", hash = "sha256:9e3fb1b0e896f14a85aa9a28d5f755daaeeb54c897b746df7a55ccb02b340f33"},
 ]
 
 [package.dependencies]
-numpy = ">=1.16.5"
+numpy = ">=1.17.3,<1.25.0"
 
 [[package]]
 name = "scipy"
@@ -3815,7 +3861,7 @@ name = "setuptools"
 version = "67.7.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "setuptools-67.7.2-py3-none-any.whl", hash = "sha256:23aaf86b85ca52ceb801d32703f12d77517b2556af839621c641fca11287952b"},
@@ -4365,6 +4411,54 @@ files = [
 dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 
 [[package]]
+name = "xarray"
+version = "2023.1.0"
+description = "N-D labeled arrays and datasets in Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "xarray-2023.1.0-py3-none-any.whl", hash = "sha256:7e530b1deafdd43e5c2b577d0944e6b528fbe88045fd849e49a8d11871ecd522"},
+    {file = "xarray-2023.1.0.tar.gz", hash = "sha256:7bee552751ff1b29dab8b7715726e5ecb56691ac54593cf4881dff41978ce0cd"},
+]
+
+[package.dependencies]
+numpy = ">=1.20"
+packaging = ">=21.3"
+pandas = ">=1.3"
+
+[package.extras]
+accel = ["bottleneck", "flox", "numbagg", "scipy"]
+complete = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "flox", "fsspec", "h5netcdf", "matplotlib", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scipy", "seaborn", "zarr"]
+docs = ["bottleneck", "cfgrib", "cftime", "dask[complete]", "flox", "fsspec", "h5netcdf", "ipykernel", "ipython", "jupyter-client", "matplotlib", "nbsphinx", "nc-time-axis", "netCDF4", "numbagg", "pooch", "pydap", "rasterio", "scanpydoc", "scipy", "seaborn", "sphinx-autosummary-accessors", "sphinx-rtd-theme", "zarr"]
+io = ["cfgrib", "cftime", "fsspec", "h5netcdf", "netCDF4", "pooch", "pydap", "rasterio", "scipy", "zarr"]
+parallel = ["dask[complete]"]
+viz = ["matplotlib", "nc-time-axis", "seaborn"]
+
+[[package]]
+name = "xarray-einstats"
+version = "0.5.1"
+description = "Stats, linear algebra and einops for xarray"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "xarray-einstats-0.5.1.tar.gz", hash = "sha256:45283e8b471ac54ac2957bc14e311f681b84dabc50c85959b9931e6f5cc60bcb"},
+    {file = "xarray_einstats-0.5.1-py3-none-any.whl", hash = "sha256:cfe63d788077b667624c96d0b0a9144323861888a4d519777083234929b0de2d"},
+]
+
+[package.dependencies]
+numpy = ">=1.20"
+scipy = ">=1.6"
+xarray = ">=2022.09.0"
+
+[package.extras]
+doc = ["furo", "jupyter-sphinx", "matplotlib", "myst-nb", "myst-parser[linkify]", "numpydoc", "sphinx (>=4)", "sphinx-copybutton", "sphinx-design", "watermark"]
+einops = ["einops"]
+numba = ["numba (>=0.55)"]
+test = ["hypothesis", "packaging", "pytest", "pytest-cov"]
+
+[[package]]
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -4387,5 +4481,5 @@ test = ["black", "flake8", "flake8-docstrings", "isort", "mypy", "pytest", "pyte
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.*,<3.12"
-content-hash = "74c0719256670ed01917935b4109cfb0aeaab686d3038746448699c765fa29be"
+python-versions = ">=3.8,<3.11"
+content-hash = "21ad91f57949f3d9b0c9a9ee44225aabacfefb99780e1e9b325e580da476a1e4"

--- a/pspline_psd/splines.py
+++ b/pspline_psd/splines.py
@@ -1,36 +1,39 @@
 import numpy as np
 from scipy.interpolate import BSpline, interp1d
-
-from .utils import get_fz
-
-
-class PSpline(BSpline):
-    """Penalized B-spline."""
-
-    pass
+from .logger import logger
 
 
-def knot_locator(data: np.ndarray, k: int, degree: int, eqSpaced: bool = False):
+def initialise_splines(
+    periodogram: np.array, k: int, degree: int,
+    omega: np.array, diffMatrixOrder: int,
+    eqSpacedKnots: bool = True
+):
+    """ Initialise the splines given a periodogram and a number of knots"""
+    V = generate_initial_spline_weights(periodogram, k)
+    knots = knot_locator(periodogram, k, degree, eqSpacedKnots)
+    db_list = dbspline(omega, knots, degree)
+    P = get_penalty_matrix(k, db_list, diffMatrixOrder, eqSpacedKnots)
+    return V, knots, db_list, P
+
+
+def knot_locator(periodogram: np.ndarray, k: int, degree: int, eqSpaced: bool = False):
     """Determines the knot locations for a B-spline basis of degree `degree` and `k` knots.
 
     Returns
     -------
     knots : np.ndarray of shape (k - degree + 1,)
 
-    #TODO: ask if there is a simple way to test if this is correct.
 
     """
     if eqSpaced:
         knots = np.linspace(0, 1, num=k - degree + 1)
         return knots
+    else:
+        logger.warning("knot_locator has not been tested for eqSpaced=False")
 
-    data = data - np.mean(data)
-    FZ = get_fz(data)
-    pdgrm = np.power(np.abs(FZ), 2)
-
-    aux = np.sqrt(pdgrm)
+    aux = np.sqrt(periodogram)
     dens = np.abs(aux - np.mean(aux)) / np.std(aux)
-    n = len(pdgrm)
+    n = len(periodogram)
 
     dens = dens / np.sum(dens)
     cumf = np.cumsum(dens)
@@ -47,42 +50,76 @@ def knot_locator(data: np.ndarray, k: int, degree: int, eqSpaced: bool = False):
     return knots
 
 
-def dbspline(x: np.ndarray, knots: np.ndarray, degree=3, normalize=True):
+def dbspline(x: np.ndarray, knots: np.ndarray, degree: int = 3, normalize: bool = True) -> np.ndarray:
     """Generate a B-spline density basis of any degree
 
     Returns:
     --------
-    B : np.ndarray of shape (len(x), len(knots) + degree -1 [I THINK])
-
-
-    #TODO: ask if there is a simple way to test if this is correct.
+    B : np.ndarray of shape (len(x), len(knots) + degree -1).
 
     """
     knots_with_boundary = np.r_[[knots[0]] * degree, knots, [knots[-1]] * degree]
     n_knots = len(knots_with_boundary)  # number of knots (including the external knots)
     assert n_knots == degree * 2 + len(knots)
 
-    # TODO: the R version has degree + 1 here... why?
     B = BSpline.design_matrix(x, knots_with_boundary, degree)
 
     if normalize:
-        # normalize the basis functions
-        mid_to_end_knots = knots_with_boundary[degree + 1 :]
+        # "normalize" the basis functions
+        mid_to_end_knots = knots_with_boundary[degree + 1:]
         start_to_mid_knots = knots_with_boundary[: (n_knots - degree - 1)]
         bs_int = (mid_to_end_knots - start_to_mid_knots) / (degree + 1)
         bs_int[bs_int == 0] = np.inf
         B = B / bs_int
+        # TODO: this doesnt sum to 1, ask @pmat747 about this
 
     assert B.shape == (len(x), len(knots) + degree - 1)
-    # assert np.allclose(np.sum(B, axis=1), 1), 'Basis functions do not sum to 1'
     return B
 
 
-def get_penalty_matrix(basis: np.ndarray, Lfdobj: int) -> np.ndarray:
+def get_penalty_matrix(k, db_list, diffMatrixOrder, eqSpacedKnots) -> np.ndarray:
     """Computes the penalty matrix for a B-spline basis of degree `degree` and `k` knots.
 
     Returns
     -------
     penalty_matrix : np.ndarray of shape (k - degree - 1, k - degree - 1)
     """
-    raise NotImplementedError('Not implemented yet')
+
+    if eqSpacedKnots:
+        P = __diff_matrix(k - 1, d=diffMatrixOrder)
+        P = np.dot(P.T, P)
+    else:
+        raise NotImplementedError('Not implemented yet')
+
+    epsilon = 1e-6
+    P = P + epsilon * np.eye(P.shape[1])  # P^(-1)=Sigma (Covariance matrix)
+    return P
+
+
+def generate_initial_spline_weights(periodogram: np.ndarray, k: int) -> np.ndarray:
+    """Generate initial weights for the spline basis functions"""
+    scaled_periodogram = periodogram / np.sum(periodogram)
+    # k equally spaced points
+    idx = np.linspace(0, len(scaled_periodogram) - 1, k)
+    idx = np.round(idx).astype(int)
+    w = scaled_periodogram[idx]
+
+    assert len(w) == k
+    w[w == 0] = 1e-50  # prevents log(0) errors
+    w = w / np.sum(w)
+    w0 = w[:-1]
+    v = np.log(w0 / (1 - np.sum(w0)))
+    # convert nans to very small
+    v[np.isnan(v)] = -1e50
+    v = v.reshape(-1, 1)
+    assert v.shape == (k - 1, 1)
+    return v
+
+
+def __diff_matrix(k, d=2):
+    assert d < k, "d must be lower than k"
+    assert np.all(np.array([d, k])) > 0, "d, k must be +ive ints"
+    out = np.eye(k)
+    for i in range(d):
+        out = np.diff(out)
+    return out.T

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8.*,<3.12"
+python = ">=3.8,<3.11"
 click = "8.1.3"
 
 black  = { version = "^22.10.0", optional = true}
@@ -59,6 +59,7 @@ bilby = "^2.1.1"
 notebook = "^6.5.4"
 jupyter = "^1.0.0"
 jupytext = "^1.14.5"
+arviz = "^0.15.1"
 
 [tool.poetry.extras]
 test = [

--- a/tests/test_bayesian_functs.py
+++ b/tests/test_bayesian_functs.py
@@ -8,8 +8,8 @@ from pspline_psd.sample.gibbs_pspline_simple import _get_initial_values
 from pspline_psd.splines import BSpline, PSpline, dbspline, get_penalty_matrix, knot_locator
 from pspline_psd.utils import get_fz, get_periodogram
 from pspline_psd.bayesian_utilities.bayesian_functions import sample_φδτ
-from pspline_psd.sample.gibbs_pspline_simple import _get_initial_values, _get_initial_spline_data, \
-    _generate_initial_weights
+from pspline_psd.sample.gibbs_pspline_simple import _get_initial_values, initialise_splines, \
+    generate_initial_spline_weights
 
 MAKE_PLOTS = True
 
@@ -43,7 +43,7 @@ def test_llike(helpers):
     data = helpers.load_raw_data()
     degree = 3
     k = 32
-    τ, δ, φ, fz, periodogram, V, omega = _get_initial_values(data, k)
+    τ, δ, φ, fz, periodogram, omega = _get_initial_values(data, k)
     fz = get_fz(data)
 
     periodogram = get_periodogram(fz)
@@ -108,9 +108,9 @@ def test_sample_prior(helpers):
     diffMatrixOrder = 2
 
     kwargs = {'data': data, 'k': k, 'degree': degree, 'omega': omega, 'diffMatrixOrder': diffMatrixOrder}
-    τ0, δ0, φ0, fz, periodogram, V0, omega = _get_initial_values(**kwargs)
-    db_list, P = _get_initial_spline_data(data, k, degree, omega, diffMatrixOrder, eqSpacedKnots=True)
-    v = _generate_initial_weights(periodogram, k)
+    τ0, δ0, φ0, fz, periodogram, omega = _get_initial_values(**kwargs)
+    db_list, P = initialise_splines(data, k, degree, omega, diffMatrixOrder, eqSpacedKnots=True)
+    v = generate_initial_spline_weights(periodogram, k)
     # create dict with k, v, τ, τα, τβ, φ, φα, φβ, δ, δα, δβ, periodogram, db_list, P
 
     kwargs = dict(

--- a/tests/test_r_package_comparisons.py
+++ b/tests/test_r_package_comparisons.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import pytest
 from pspline_psd.utils import get_fz
-from pspline_psd.sample.gibbs_pspline_simple import _generate_initial_weights
+from pspline_psd.splines import generate_initial_spline_weights
 from pspline_psd.splines import dbspline, knot_locator
 from pspline_psd.bayesian_utilities.whittle_utilities import get_unormalised_psd
 from pspline_psd.bayesian_utilities.bayesian_functions import llike
@@ -61,8 +61,8 @@ def __compute_r_psd(data, k, degree, omega):
 def __compute_py_psd(data, k, degree, omega):
     fz = get_fz(data)
     pdgrm = np.power(np.abs(fz), 2)
-    v = _generate_initial_weights(pdgrm, k)
-    knots = knot_locator(data=data, k=k, degree=degree, eqSpaced=True)
+    v = generate_initial_spline_weights(pdgrm, k)
+    knots = knot_locator(periodogram=None, k=k, degree=degree, eqSpaced=True)
     dblist = dbspline(x=omega, knots=knots, degree=degree)
     psd = get_unormalised_psd(v, dblist)
 
@@ -132,9 +132,9 @@ def test_mcmc_comparison(helpers):
     plt.rcParams['font.family'] = 'sans-serif'
     plt.plot(figsize=(8, 4))
     plt.scatter(psd_x, periodogram, color='k', label='Data', s=0.75)
-    plt.plot(psd_x, py_psd, color='tab:orange', alpha=0.5, label='Python')
+    plt.plot(psd_x, py_psd, color='tab:orange', alpha=0.5, label='Python (CI)')
     plt.fill_between(psd_x, py_psd_p05, py_psd_p95, color='tab:orange', alpha=0.2, linewidth=0.0)
-    plt.plot(psd_x, r_psd, color='tab:green', alpha=0.5, label='R')
+    plt.plot(psd_x, r_psd, color='tab:green', alpha=0.5, label='R (uniform CI)')
     plt.fill_between(psd_x, r_psd_p05, r_psd_p95, color='tab:green', alpha=0.2, linewidth=0.0)
     # turn off grid
     plt.grid(False)

--- a/tests/test_simple_example.py
+++ b/tests/test_simple_example.py
@@ -7,9 +7,10 @@ def test_simple_example(helpers):
     data = helpers.load_raw_data()
     data = data - data.mean()
 
+
     fn = f"{helpers.OUTDIR}/sample_metadata.png"
-    gibbs_pspline_simple(
-        data=data, Ntotal=2000, burnin=100, degree=3,
+    mcmc = gibbs_pspline_simple(
+        data=data, Ntotal=1000   , burnin=200, degree=3,
         eqSpacedKnots=True, compute_psds=True, metadata_plotfn=fn
     )
     assert os.path.exists(fn)

--- a/tests/test_splines.py
+++ b/tests/test_splines.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from pspline_psd.splines import BSpline, PSpline, knot_locator, dbspline
+from pspline_psd.splines import BSpline, knot_locator, dbspline
 from pspline_psd.utils import get_fz
 from pspline_psd.sample.gibbs_pspline_simple import _get_initial_values
 from scipy import interpolate
@@ -15,7 +15,6 @@ def test_spline_creation():
     coeff = np.array([-1, 2, 0, -1])
 
     bspline = BSpline(t=knots, c=coeff, k=degree)
-    pspline = PSpline(t=knots, c=coeff, k=degree)
 
     assert np.allclose(bspline(0.5), pspline(0.5))
 
@@ -52,7 +51,7 @@ def test_basis_same_as_r_package_basis(helpers):
     # generate basis functions
     degree = 3
     k = 32
-    τ, δ, φ, fz, periodogram, V, omega = _get_initial_values(data, k)
+    τ, δ, φ, fz, periodogram, omega = _get_initial_values(data, k)
     knots = knot_locator(data, k=k, degree=degree, eqSpaced=True)
     db_list = dbspline(omega, knots, degree=degree).T
 


### PR DESCRIPTION
This is trying to add `arviz.InferenceData` to store the posterior, however, some strange bug has crept in: 

Previous:
![sample_metadata](https://github.com/avivajpeyi/pspline_psd/assets/15642823/70d2ae7f-12e3-4514-af60-12cc02208a49)

Idata version:
![sample_metadata_0](https://github.com/avivajpeyi/pspline_psd/assets/15642823/aacd9653-1b63-4603-ac59-da734cbd1c82)


The frac-accepted is flat.. hmm