### PR TITLE
Fix linearly spaced LISA noise fit example

### DIFF
--- a/src/slipper/sample/base_sampler.py
+++ b/src/slipper/sample/base_sampler.py
@@ -92,7 +92,7 @@ class BaseSampler(ABC):
             pbar.set_postfix(
                 dict(
                     lnP=self.samples["lpost_trace"][itr - 1],
-                    accept=self.samples["acceptance_fraction"][itr - 1],
+                    accept=f"{self.samples['acceptance_fraction'][itr - 1]:.2f}",
                 )
             )
         self._compile_sampling_result()

--- a/src/slipper/sample/post_processing.py
+++ b/src/slipper/sample/post_processing.py
@@ -86,7 +86,9 @@ def generate_spline_quantiles(
     # assert no nans in psd_with_unc
     if not np.all(np.isfinite(psd_with_unc)):
         num_nans_each_row = np.sum(~np.isfinite(psd_with_unc), axis=1)
-        raise ValueError("PSD quantiles has non-finite values.")
+        raise ValueError(
+            f"PSD quantiles has non-finite values ({num_nans_each_row})."
+        )
     return psd_with_unc
 
 

--- a/src/slipper/sample/post_processing.py
+++ b/src/slipper/sample/post_processing.py
@@ -2,14 +2,16 @@ import numpy as np
 from scipy.stats import median_abs_deviation
 from tqdm.auto import trange
 
+from slipper.logger import logger
+
 from ..splines import build_spline_model
 
 
 def generate_spline_posterior(
-    spline_len,
-    db_list,
-    tau_samples,
-    weight_samples,
+    spline_len: int,
+    db_list: np.ndarray,
+    tau_samples: np.ndarray,
+    weight_samples: np.ndarray,
     verbose: bool = False,
     logged: bool = False,
 ):
@@ -21,10 +23,12 @@ def generate_spline_posterior(
         n, desc="Generating Spline posterior", disable=not verbose
     ):
         kwargs[weight_key] = weight_samples[i, :]
-        if logged:
-            splines[i, :] = build_spline_model(**kwargs)  # + tau_samples[i]
-        else:
-            splines[i, :] = build_spline_model(**kwargs) * tau_samples[i]
+        splines[i, :] = build_spline_model(**kwargs)
+
+    if logged:
+        splines = np.exp(splines)
+    else:
+        splines *= tau_samples[:, None]
     return splines
 
 
@@ -45,15 +49,16 @@ def generate_spline_quantiles(
         verbose,
         logged=logged_splines,
     )
+    splines_median = np.nanquantile(splines, 0.5, axis=0)
+    splines_quants = np.nanquantile(splines, [0.05, 0.95], axis=0)
+
     if logged_splines:
-        splines = np.exp(splines)
+        lnsplines = np.log(splines)
+    else:
+        # TBH I don't understand this part -- taken from @patricio's code
+        # See internal_gibs_utils and line 395 of gibs-sample-simple
+        lnsplines = __logfuller(splines)
 
-    splines_median = np.quantile(splines, 0.5, axis=0)
-    splines_quants = np.quantile(splines, [0.05, 0.95], axis=0)
-
-    # TBH I don't understand this part -- taken from @patricio's code
-    # See internal_gibs_utils and line 395 of gibs-sample-simple
-    lnsplines = __logfuller(splines)
     lnsplines_median = np.median(lnsplines, axis=0)
     lnsplines_mad = median_abs_deviation(lnsplines, axis=0)
     lnsplines_uniform_max = __uniformmax(lnsplines)
@@ -66,16 +71,22 @@ def generate_spline_quantiles(
         ]
     )
 
+    psd_with_unc = np.vstack([splines_median, splines_quants])
     if uniform_bands:
-        psd_with_unc = np.vstack([splines_median, uniform_psd_quants])
-    else:
-        psd_with_unc = np.vstack([splines_median, splines_quants])
+        psd_with_unif_unc = np.vstack([splines_median, uniform_psd_quants])
+        if not np.all(np.isfinite(psd_with_unif_unc)):
+            logger.warning(
+                "Uniform bands PSD has non-finite values, using quantiles instead."
+            )
+        else:
+            psd_with_unc = psd_with_unif_unc
 
     assert psd_with_unc.shape == (3, spline_len)
 
     # assert no nans in psd_with_unc
     if not np.all(np.isfinite(psd_with_unc)):
-        raise ValueError("psd_with_unc has non-finite values.")
+        num_nans_each_row = np.sum(~np.isfinite(psd_with_unc), axis=1)
+        raise ValueError("PSD quantiles has non-finite values.")
     return psd_with_unc
 
 

--- a/src/slipper/splines/utils.py
+++ b/src/slipper/splines/utils.py
@@ -108,24 +108,19 @@ def __get_unscaled_spline(
     return density_mixture(densities=db_list.T, weights=weights)
 
 
-def _lnlikelihood(data: np.ndarray, model: np.ndarray, **lnl_kwargs) -> float:
+def _lnlikelihood(
+    lndata: np.ndarray, lnmodel: np.ndarray, **lnl_kwargs
+) -> float:
     """Whittle log likelihood"""
 
-    # replace any zeros to near-zero values to avoid log(0) = -inf
-    data[data == 0] = 1e-50
-    model[model == 0] = 1e-50
-
-    lndata = np.log(data)
-    lnmodel = np.log(model)
-
-    n = len(data)
+    n = len(lndata)
     is_even = n % 2 == 0
     if is_even:  # remove first elememt
         lnmodel = lnmodel[1:]
         lndata = lndata[1:]
     else:  # remove last element
-        lnmodel = model[1:-1]
-        lndata = data[1:-1]
+        lnmodel = lnmodel[1:-1]
+        lndata = lndata[1:-1]
 
     integrand = lnmodel + np.exp(lndata - lnmodel - np.log(2 * np.pi))
     lnlike = -np.sum(integrand) / 2

--- a/src/slipper/splines/utils.py
+++ b/src/slipper/splines/utils.py
@@ -2,9 +2,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 
-def density_mixture(
-    weights: np.ndarray, densities: np.ndarray, epsilon=1e-20
-) -> np.ndarray:
+def density_mixture(weights: np.ndarray, densities: np.ndarray) -> np.ndarray:
     """build a density mixture, given mixture weights and densities
 
     weights:
@@ -16,10 +14,7 @@ def density_mixture(
         raise ValueError(
             f"weights ({weights.shape}) and densities ({densities.shape}) must have the same length",
         )
-    res = np.sum(weights[:, None] * densities, axis=0)
-    # res = np.maximum(res, epsilon)  # dont allow values below epsilon
-
-    return res
+    return np.sum(weights[:, None] * densities, axis=0)
 
 
 def unroll_list_to_new_length(old_list, n):
@@ -91,7 +86,7 @@ def convert_v_to_weights(v: np.ndarray):
 
 
 def __get_unscaled_spline(
-    db_list: np.ndarray, epsilon=1e-20, v: np.ndarray = None, weights=None
+    db_list: np.ndarray, v: np.ndarray = None, weights=None
 ):
     """Compute unscaled spline using mixture of B-splines with weights from v
 
@@ -110,9 +105,7 @@ def __get_unscaled_spline(
     """
     if weights is None:
         weights = convert_v_to_weights(v)
-    combined = density_mixture(densities=db_list.T, weights=weights)
-    # return np.maximum(combined, epsilon)
-    return combined
+    return density_mixture(densities=db_list.T, weights=weights)
 
 
 def _lnlikelihood(data: np.ndarray, model: np.ndarray, **lnl_kwargs) -> float:

--- a/tests/test_lisa_cases.py
+++ b/tests/test_lisa_cases.py
@@ -44,9 +44,9 @@ def test_fit_lisa_noise_linear_knots(tmpdir):
     res = LogPsplineSampler.fit(
         data=pdgrm,
         outdir=outdir,
-        sampler_kwargs=dict(Ntotal=200, n_checkpoint_plts=3, burnin=100),
+        sampler_kwargs=dict(Ntotal=200, n_checkpoint_plts=2, burnin=100),
         spline_kwargs=dict(
-            k=50,
+            k=30,
             knot_locator_type=KnotLocatorType.linearly_spaced,
         ),
     )
@@ -91,7 +91,7 @@ def test_fit_list_wd_background(tmpdir):
         data=pdgrm,
         outdir=outdir,
         sampler_kwargs=dict(
-            Ntotal=100, n_checkpoint_plts=2, burnin=10, thin=1
+            Ntotal=200, n_checkpoint_plts=2, burnin=100, thin=1
         ),
         spline_kwargs=dict(
             k=30,

--- a/tests/test_lisa_cases.py
+++ b/tests/test_lisa_cases.py
@@ -33,7 +33,7 @@ def __plot_res(pdgrm, res, title):
     return fig
 
 
-@pytest.mark.skip("Fails due to -inf qunatiles")
+# @pytest.mark.skip("Fails due to -inf qunatiles")
 def test_fit_lisa_noise_linear_knots(tmpdir):
     np.random.seed(42)
     pdgrm = lisa_noise_periodogram()
@@ -44,11 +44,10 @@ def test_fit_lisa_noise_linear_knots(tmpdir):
     res = LogPsplineSampler.fit(
         data=pdgrm,
         outdir=outdir,
-        sampler_kwargs=dict(Ntotal=100, n_checkpoint_plts=2, burnin=10),
+        sampler_kwargs=dict(Ntotal=200, n_checkpoint_plts=3, burnin=100),
         spline_kwargs=dict(
             k=50,
             knot_locator_type=KnotLocatorType.linearly_spaced,
-            min_val=10**-3,
         ),
     )
     fig = __plot_res(pdgrm, res, "LISA noise")


### PR DESCRIPTION
Now, with 30 knots and 100 steps: 

![fit](https://github.com/avivajpeyi/pyslipper/assets/15642823/c24d5a0e-e982-4c46-90d3-55a8c2a78887)

Note: this may be due to the improved initial weights 
![init_weights](https://github.com/avivajpeyi/pyslipper/assets/15642823/5b84dce7-6d3a-4988-819d-7dd6e93cf150)
